### PR TITLE
chore(cli): add gemini-cli local setup with safe file-edit scope

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,10 @@
+{
+    "general": { "checkpointing": { "enabled": true } },
+    "tools": {
+        "allowed": ["read_file", "write_file", "replace", "glob", "search_file_content", "web_fetch"],
+        "blocked": ["run_shell_command"]
+    },
+    "workspace": {
+        "includeDirectories": ["backend", "frontend"]
+    }
+}


### PR DESCRIPTION
feat(backend): unify error responses via FastAPI & Starlette HTTPException handlers
docs: add local usage and verification steps

## Summary

* **何を**: Gemini CLI をローカル導入し、**backend/frontend 配下のみ**を編集対象に限定。サンプルとして `backend/app/main.py` に **FastAPI / Starlette 双方の HTTPException ハンドラ**を追加し、404 なども `{"error": "..."} ` で統一。
* **なぜ**: 安全なスコープで AI エージェント編集を有効化し、開発補助を加速するため（Secrets/CI は触らない制約を順守）。

## Changes

* `backend/app/main.py`

  * 追加: `from starlette.exceptions import HTTPException as StarletteHTTPException`
  * 追加: `@app.exception_handler(StarletteHTTPException)` による 404 等の統一 JSON エラーレスポンス
  * 追加: `@app.exception_handler(HTTPException)` による FastAPI 側の統一 JSON エラーレスポンス
  * 付随: 必要 import の追加（`HTTPException`, `Request`, `JSONResponse`）
* `.gemini/settings.json`（プロジェクト直下、任意だが推奨）

  * `workspace.includeDirectories`: `["backend","frontend"]`
  * `tools.allowed`: `["read_file","write_file","replace","glob","search_file_content","web_fetch"]`
  * `tools.blocked`: `["run_shell_command"]`
* （任意）README に「ローカル導入手順・確認コマンド・DoD」を追記

## Test

* [ ] **Actionsでエラーがないことを確認**
* [ ] **READMEの更新**
* 手元確認（実施済み）

  * `gemini --help` が通る
  * 制限付きで編集実行

    ```bash
    gemini --include-directories backend,frontend \
      --approval-mode=auto_edit \
      --allowed-tools write_file,replace,read_file,glob \
      -m gemini-1.5-flash \
      "Open backend/app/main.py and add global error handlers that return JSONResponse {\"error\": ...} for both FastAPI and Starlette HTTPException. Keep other code unchanged and save."
    ```
  * 差分確認: `git diff backend/app/main.py`
  * サーバ起動（ルートから）:
    `uv run --project backend uvicorn --app-dir backend app.main:app --reload`
  * 404 確認:
    `curl -sS "http://127.0.0.1:8000/__no_such_endpoint__"` → `{"error":"Not Found"}`
  * 既存テスト: `uv run --project backend pytest -q`

## Notes

* ブランチ: `chore/setup-gemini-cli`
* レポジトリ: [https://github.com/Kenta-morimori/WeatherForecastApp](https://github.com/Kenta-morimori/WeatherForecastApp)
* プロジェクトボード: [https://github.com/users/Kenta-morimori/projects/7/views/1](https://github.com/users/Kenta-morimori/projects/7/views/1)
* API キー発行（ローカルのみ）: Google AI Studio → `export GEMINI_API_KEY="..."`
* 目的: **ローカル開発補助の土台整備**（Secrets/CI 無変更、backend/frontend のみ編集可能）

