### PR TITLE
Dockerize backend: add Dockerfile, compose, .dockerignore, and env ex…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,11 +6,31 @@ MODEL_BACKEND=regression
 # 学習アーティファクト: backend/models/YYYYMMDD_<gitSHA>_gbdt.joblib
 MODEL_PATH=./models/latest_gbdt.joblib
 
+# === Observability / Logging ===
+# 構造化ログの出力レベル（INFO/DEBUG/WARN/ERROR）
+LOG_LEVEL=INFO
+
+# === CORS ===
+# 本番フロントのオリジン + ローカル開発用
+# ※ 末尾スラなし・カンマ区切りで列挙
+ALLOW_ORIGINS=https://weatherforecastapp-cicv.onrender.com,http://localhost:3000,http://127.0.0.1:3000
+# 許可するHTTPメソッド
+ALLOW_METHODS=GET,POST,OPTIONS
+# 許可するリクエストヘッダ（将来の拡張を見据えて * でOK）
+ALLOW_HEADERS=*
+# ブラウザへ露出させるレスポンスヘッダ（Requestトレース用に必須）
+EXPOSE_HEADERS=X-Request-ID
+# Cookie等の認証情報を跨ぐ場合は true（不要なら false でも可）
+ALLOW_CREDENTIALS=true
+
 # === Open-Meteo client ===
 OPEN_METEO_BASE=https://api.open-meteo.com
 OPEN_METEO_UA=WeatherForecastApp/0.1 (+https://github.com/Kenta-morimori/WeatherForecastApp)
+# 既存の hourly 用TTL（秒）
 OPEN_METEO_CACHE_TTL=300
+# 追加: /forecast（日次）用TTL（秒）
+OPEN_METEO_DAILY_CACHE_TTL=300
 
-# === CORS ===
-# 本番ではフロントのオリジンを指定（例: https://app.example.com）
-ALLOW_ORIGINS=http://localhost:3000
+# === Local/Docker 起動用（任意） ===
+# Uvicornのポート指定が必要な環境で利用
+PORT=8000

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+# backend/Dockerfile
+FROM python:3.11-slim
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+
+# 依存定義だけ先に
+COPY backend/pyproject.toml /app/backend/pyproject.toml
+
+# lock 無くてもOK。あれば別途 COPY してもよい
+RUN uv sync --project /app/backend || true
+
+# ソース一式
+COPY backend/ /app/backend/
+
+# ★ backend を import path に載せる最も明示的な方法
+CMD ["uv","run","--project","backend","uvicorn","app.main:app", "--app-dir","backend","--host","0.0.0.0","--port","8000","--loop","uvloop"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    env_file: backend/.env
+    environment:
+      # Render 互換にしたい場合などは PORT を明示
+      PORT: "${PORT:-8000}"
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+    # 開発時ホットリロードしたいなら以下2行を有効化
+    # volumes:
+    #   - ./backend:/app/backend
+    # command: ["uv", "run", "--project", "backend", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--loop", "uvloop", "--reload"]


### PR DESCRIPTION
## PRタイトル

**Dockerize backend: add Dockerfile, docker-compose, .dockerignore, and env example**

## PR本文（そのまま使えます）

### Summary

* **何を**: バックエンドの Docker 化（`backend/Dockerfile` とルートの `docker-compose.yml` を追加）し、`.dockerignore` と `backend/.env.example` を整備。
* **なぜ**: ローカルでの再現性・起動容易性向上（`docker compose up -d --build` だけで動作）。本番(Render)と近い実行形態で挙動確認でき、可観測性項目（構造化ログ/メトリクス/SLO）もコンテナで検証可能にするため。

### Changes

* 新規: `backend/Dockerfile`

  * `uv` + `uvicorn` で起動、`--app-dir backend` で確実に `app.main:app` を読み込み
* 新規: ルート `docker-compose.yml`

  * `api` サービス（ポート`:8000`）、`env_file: backend/.env` を読み込み
* 新規/更新: ルート `.dockerignore`

  * `.git`, `frontend/`, `**/node_modules`, `__pycache__` などを除外して軽量ビルド
* 更新: `backend/.env.example`

  * 追加: `LOG_LEVEL`, `ALLOW_METHODS`, `ALLOW_HEADERS`, `EXPOSE_HEADERS`, `ALLOW_CREDENTIALS`, `OPEN_METEO_DAILY_CACHE_TTL`, `PORT`
  * `ALLOW_ORIGINS` に本番フロント `https://weatherforecastapp-cicv.onrender.com` を追記
* ドキュメント（README想定・抜粋）

  * Docker 起動手順と環境変数一覧を追記（`docker compose up -d --build` で起動）

### How to run (local)

```bash
# 初回のみ .env を作成（backend/.env はコミットしない）
cp backend/.env.example backend/.env

# ビルド & 起動
docker compose up -d --build

# 動作確認
curl -i http://127.0.0.1:8000/health
curl -s "http://127.0.0.1:8000/forecast?lat=35.68&lon=139.76&tz=Asia/Tokyo" | jq .
curl -s http://127.0.0.1:8000/metrics/simple | jq .
```

### Test

* [x] `docker compose up -d --build` で起動し、`/health` が 200
* [x] `/forecast` が 200 かつ JSON スキーマ整合
* [x] `/metrics/simple` に `p95` 等が出力
* [x] `X-Request-ID` がレスポンスヘッダで露出（CORSの `EXPOSE_HEADERS` 反映）
* [ ] README 更新（Docker 起動手順と環境変数の追記）

### Notes

* **注意**: `backend/.env` は開発用のため **コミットしない**（`.env.example` のみコミット）
* **Render 本番**は `.env` を読まないため、ダッシュボードの **Environment Variables** に同値を登録
* 将来拡張候補:

  * 起動時プリウォーム（`PREWARM_*` 環境変数）でコールド時レイテンシ緩和
  * GH Actions でのコンテナビルド・脆弱性スキャン・プッシュ
